### PR TITLE
Add alt text support to built in index image and author avatars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ items = [
 [extra.index]
 title = "Main title"
 image = "https://via.placeholder.com/200"
+image_alt = "Placeholder text describing the index's image."
 
 [extra.default_author]
 name = "John Doe"
 avatar = "https://via.placeholder.com/200"
+avatar_alt = "Placeholder text describing the default author's avatar."
 
 [extra.social]
 github = "https://github.com/johndoe"

--- a/templates/categories/single.html
+++ b/templates/categories/single.html
@@ -54,11 +54,11 @@
               {% if page.extra.author.name %}
                 <span class="ml-1">{{ page.extra.author.name }}</span>
                 {% if page.extra.author.avatar %}
-                  <img class="rounded-full h-9 w-9 ml-1" src="{{ page.extra.author.avatar }}">
+                  <img class="rounded-full h-9 w-9 ml-1" src="{{ page.extra.author.avatar }}"{% if page.extra.author.avatar_alt %} alt="{{ page.extra.author.avatar_alt }}"{% endif %}>
                 {% endif %}
               {% else %}
                 <span class="ml-1">{{ config.extra.default_author.name }}</span>
-                <img class="rounded-full h-9 w-9 ml-1" src="{{ config.extra.default_author.avatar }}">
+                <img class="rounded-full h-9 w-9 ml-1" src="{{ config.extra.default_author.avatar }}" alt="{{ config.extra.default_author.avatar_alt }}">
               {% endif %}
             </span>
           </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
   <h1 class="text-xl text-bold">
     {{ config.extra.index.title }}
   </h1>
-  <img class="rounded-full h-40 w-40" src="{{ config.extra.index.image }}" alt="">
+  <img class="rounded-full h-40 w-40" src="{{ config.extra.index.image }}" alt="{{ config.extra.index.image_alt }}">
   <div class="flex flex-wrap space-x-4 mt-7">
     {% if config.extra.social.github %}
       <a href="{{config.extra.social.github}}" target="_blank">

--- a/templates/page.html
+++ b/templates/page.html
@@ -49,11 +49,11 @@
           {% if page.extra.author.name %}
             <span class="ml-1">{{ page.extra.author.name }}</span>
             {% if page.extra.author.avatar %}
-              <img class="rounded-full h-9 w-9 ml-1" src="{{ page.extra.author.avatar }}">
+              <img class="rounded-full h-9 w-9 ml-1" src="{{ page.extra.author.avatar }}"{% if page.extra.author.avatar_alt %} alt="{{ page.extra.author.avatar_alt }}"{% endif %}>
             {% endif %}
           {% else %}
             <span class="ml-1">{{ config.extra.default_author.name }}</span>
-            <img class="rounded-full h-9 w-9 ml-1" src="{{ config.extra.default_author.avatar }}">
+            <img class="rounded-full h-9 w-9 ml-1" src="{{ config.extra.default_author.avatar }}" alt="{{ config.extra.default_author.avatar_alt }}">
           {% endif %}
         </span>
       </div>

--- a/templates/tags/single.html
+++ b/templates/tags/single.html
@@ -54,11 +54,11 @@
               {% if page.extra.author.name %}
                 <span class="ml-1">{{ page.extra.author.name }}</span>
                 {% if page.extra.author.avatar %}
-                  <img class="rounded-full h-9 w-9 ml-1" src="{{ page.extra.author.avatar }}">
+                  <img class="rounded-full h-9 w-9 ml-1" src="{{ page.extra.author.avatar }}"{% if page.extra.author.avatar_alt %} alt="{{ page.extra.author.avatar_alt }}"{% endif %}>
                 {% endif %}
               {% else %}
                 <span class="ml-1">{{ config.extra.default_author.name }}</span>
-                <img class="rounded-full h-9 w-9 ml-1" src="{{ config.extra.default_author.avatar }}">
+                <img class="rounded-full h-9 w-9 ml-1" src="{{ config.extra.default_author.avatar }}" alt="{{ config.extra.default_author.avatar_alt }}">
               {% endif %}
             </span>
           </div>

--- a/theme.toml
+++ b/theme.toml
@@ -73,10 +73,12 @@ items = [
 [extra.index]
 title = "Main title"
 image = "https://via.placeholder.com/200"
+image_alt = "Placeholder text describing the index's image."
 
 [extra.default_author]
 name = "John Doe"
 avatar = "https://via.placeholder.com/200"
+avatar_alt = "Placeholder text describing the default author's avatar."
 
 [extra.social]
 github = "https://github.com/johndoe"


### PR DESCRIPTION
Small accessibility improvement 😸 

Adds `image_alt` for index's `image` and `avatar_alt` for both the default_author's `avatar` and any page's author `avatar`. For symmetry with their "parent" picture, `index.image_alt` and `default_author.avatar_alt` have default values and are assumed to exist, while `page.author.avatar_alt` is optional, like its parent `page.author.avatar_alt`.