### PR TITLE
Minor style fixes and adaptions

### DIFF
--- a/templates/categories/list.html
+++ b/templates/categories/list.html
@@ -7,7 +7,7 @@
   </h1>
   <p class="text-bold text-xl mt-4">{{ terms | length }} categories</p>
 
-  <div class="flex sm:flex-row flex-col sm:gap-x-7 gap-y-5 mt-6">
+  <div class="flex flex-wrap sm:flex-row flex-col sm:gap-x-7 gap-y-5 mt-6">
   {% for category in terms %}
     <a href="{{ category.permalink | safe }}" class="flex items-center space-x-2">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/templates/categories/list.html
+++ b/templates/categories/list.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block content %}
-<div class="flex items-center flex-col mt-10">
+<div class="flex items-center flex-col mt-10 px-4">
   <h1 class="text-2xl text-bold">
     Categories
   </h1>

--- a/templates/categories/single.html
+++ b/templates/categories/single.html
@@ -1,11 +1,11 @@
 {% extends "layout.html" %}
 
 {% block content %}
-<div class="flex items-center flex-col mt-10">
+<div class="flex items-center flex-col mt-10 px-4">
   <h1 class="text-2xl text-bold mb-6">
     Category : {{ term.name }}
   </h1>
-  <div class="flex flex-col gap-y-6 w-full px-4 sm:w-2/3">
+  <div class="flex flex-col gap-y-6 w-full sm:w-2/3">
     {% if paginator %}
     {% set pages = paginator.pages %}
     {% else %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block content %}
-<div class="flex items-center flex-col mt-40">
+<div class="flex items-center flex-col mt-16">
   <h1 class="text-xl text-bold">
     {{ config.extra.index.title }}
   </h1>

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,7 +74,7 @@
   </div>
 
           <!-- Content -->
-        <div class="text-bold mt-2">
+        <div class="text-bold mt-2 w-2/3 text-center p-4">
           {{ section.content | safe }}
         </div>
 </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -230,7 +230,7 @@
 
     <!----------------------------- Mobile menu ----------------------------->
     <div id="mobile-menu" class="sm:hidden fixed z-10 overflow-hidden">
-      <div class="nav-links flex flex-col space-y-4 items-center w-screen dark:bg-gray-800 transition-all ease-out duration-500 h-0">
+      <div class="nav-links flex flex-col space-y-4 items-center w-screen bg-gray-200 dark:bg-gray-800 transition-all ease-out duration-500 h-0">
         <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
         {% for item in config.extra.navbar.items %}
           {% if lang == item.lang %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -297,7 +297,7 @@
     <div class="mt-16 border-t-2 border-gray-300 flex flex-col items-center">
       <div class="sm:w-2/3 text-center py-6">
         <p class="text-sm text-black dark:text-white font-bold mb-2">
-          © 2023 <a href="https://www.getzola.org/themes/blow/">blow</a> theme made with <a href="https://tailwindcss.com/" target="_blank">tailwindcss</a> for <a href="https://www.getzola.org/" target="_blank">Zola</a>
+          © {{ now() | date(format="%Y") }} <a href="https://www.getzola.org/themes/blow/">blow</a> theme made with <a href="https://tailwindcss.com/" target="_blank">tailwindcss</a> for <a href="https://www.getzola.org/" target="_blank">Zola</a>
         </p>
       </div>
     </div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -6,7 +6,7 @@
       {{ page.title }}
     </h1>
 </div>
-<div class="flex gap-x-8">
+<div class="flex gap-x-8 p-4 justify-center">
   <div class="flex flex-col sm:w-3/4 w-full border border-2 border-gray-200 dark:border-black rounded-xl p-5 shadow-2xl bg-gray-200 dark:bg-gray-800">
 
     <div class="flex flex-col py-2 justify-center">

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block content %}
-<div class="flex">
+<div class="flex px-4">
    <h1 class="text-2xl text-bold my-6 mx-auto">
       {{ page.title }}
     </h1>

--- a/templates/tags/list.html
+++ b/templates/tags/list.html
@@ -7,7 +7,7 @@
   </h1>
   <p class="text-bold text-xl mt-4">{{ terms | length }} tags</p>
 
-  <div class="flex sm:flex-row flex-col sm:gap-x-7 gap-y-5 mt-6">
+  <div class="flex flex-wrap sm:flex-row flex-col sm:gap-x-7 gap-y-5 mt-6">
   {% for tag in terms %}
     <a href="{{ tag.permalink | safe }}" class="flex items-center space-x-2">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/templates/tags/list.html
+++ b/templates/tags/list.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block content %}
-<div class="flex items-center flex-col mt-10">
+<div class="flex items-center flex-col mt-10 px-4">
   <h1 class="text-2xl text-bold">
     Tags
   </h1>

--- a/templates/tags/single.html
+++ b/templates/tags/single.html
@@ -1,11 +1,11 @@
 {% extends "layout.html" %}
 
 {% block content %}
-<div class="flex items-center flex-col mt-10">
+<div class="flex items-center flex-col mt-10 px-4">
   <h1 class="text-2xl text-bold mb-6">
     Tag : {{ term.name }}
   </h1>
-  <div class="flex flex-col gap-y-6 w-full px-4 sm:w-2/3">
+  <div class="flex flex-col gap-y-6 w-full sm:w-2/3">
     {% if paginator %}
     {% set pages = paginator.pages %}
     {% else %}


### PR DESCRIPTION
The following fixes were done to the styling of the theme:
- Added missing background definition for light theme to mobile menu (the background was transparent before).
- Wrap categories and tags lists if there are too many items for one line.
- Align page content in the center so that it does not look off when the table of content is disabled.
- Always use current year for the copyright notice in the footer

The following adaptions were done to the styling of the theme:
- Distance to the page borders for content blocks which is especially helpful for mobile layouts, where the content might touch the screen borders otherwise.
- Moved content on index page more up so that it does not look off on small mobile screens or with multi-line content text on the page.
- Restrict width of the content div on the index page so that the line wrap happens for larger content texts before the text runs over the whole screen.


I tried to test that the changes do not break your pages by building it with your website repository (https://github.com/tchartron/tchartron-zola/). However, the build fails due to issues unrelated to my changes. Please let me know, if I can test that somehow.