### PR TITLE
Allows the footer to be customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ highlight_themes_css = [
 ]
 ```
 
+## Custom Footer Content
+To overwrite the default footer (copyright notice), extend the `layout.html` template of the theme as described in the [Zola documentation](https://www.getzola.org/documentation/themes/extending-a-theme/#overriding-a-block) by creating a `layout.html` with the following content in your `templates` directory:
+
+```jinja
+{% extends "blow/templates/layout.html" %}
+
+{% block content_footer %}
+Here is my own footer with a <a href="http://example.com">link</a>.
+{% endblock %}
+```
+
 ## Features
 - [X] Dark/Light modes (with syntax highlighting depending on selected theme)
 - [X] Customizable navbar links

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -297,7 +297,9 @@
     <div class="mt-16 border-t-2 border-gray-300 flex flex-col items-center">
       <div class="sm:w-2/3 text-center py-6">
         <p class="text-sm text-black dark:text-white font-bold mb-2">
+          {% block content_footer %}
           © {{ now() | date(format="%Y") }} <a href="https://www.getzola.org/themes/blow/">blow</a> theme made with <a href="https://tailwindcss.com/" target="_blank">tailwindcss</a> for <a href="https://www.getzola.org/" target="_blank">Zola</a>
+          {% endblock %}
         </p>
       </div>
     </div>


### PR DESCRIPTION
Adding a block around the default footer content, so that it can be overwritten when using the theme.

As I'm new to working with Zola, I am not sure, if this is the right way to allow such a customization. Feel free, to point out a better approach, if there is one.